### PR TITLE
Fix bug in joining items table and users table

### DIFF
--- a/apps/backend/database/items.go
+++ b/apps/backend/database/items.go
@@ -315,7 +315,8 @@ func (r *ItemDatabase) ListItems(ctx context.Context, p ListItemsParams) ([]Item
 			i.highest_bid_id::text, i.highest_bid_amount,
 			i.highest_bidder_id::text, i.highest_bid_time,
             i.created_at, i.updated_at
-        FROM items i, users u
+        FROM items i
+		JOIN users u ON u.id = i.seller_id
         WHERE
             ($1::item_status IS NULL OR status = $1::item_status)
 			AND ($2::uuid IS NULL OR i.seller_id = $2::uuid)


### PR DESCRIPTION
This pull request updates the way items and users are joined in the `ListItems` query to improve query accuracy and maintainability. The most important change is switching from an implicit join to an explicit `JOIN` clause, ensuring that only items with a valid seller are returned.

**Database query improvements:**

* Changed the SQL query in `ListItems` to use an explicit `JOIN` between the `items` and `users` tables on the seller ID, instead of an implicit join, making the relationship clearer and preventing accidental cross joins.

**Related Issues:**

* Resolved #77 