### PR TITLE
Fix get single item SQL

### DIFF
--- a/apps/backend/database/items.go
+++ b/apps/backend/database/items.go
@@ -184,7 +184,7 @@ func (r *ItemDatabase) GetItemByID(ctx context.Context, itemID string) (Item, er
 		FROM items i, users u
 		WHERE
 			i.id = $1::uuid
-			AND u.id = $1::uuid;
+			AND u.id = i.seller_id::uuid;
 	`, itemID).Scan(
 		&it.ID, &it.SellerID,
 		&it.SellerUsername,


### PR DESCRIPTION
This pull request corrects a bug in the SQL query used by the `GetItemByID` method in `apps/backend/database/items.go`. The query now properly joins the `users` table on the item's `seller_id` instead of incorrectly using the item's own ID, ensuring that the seller information is fetched accurately.

- Bug fix: Updated the SQL join condition in the `GetItemByID` method to join `users` on `i.seller_id` rather than `i.id`, so that the seller's information is correctly retrieved.

Related Issues:

- Resolved #80 