### PR TITLE
Fix typo in update highest bid trigger

### DIFF
--- a/apps/backend/migrations/functions/update_item_highest_bid_after_insert.sql
+++ b/apps/backend/migrations/functions/update_item_highest_bid_after_insert.sql
@@ -5,7 +5,7 @@ BEGIN
     SET
         highest_bid_amount = NEW.price,
         highest_bidder_id  = NEW.user_id,
-        highest_bid_time   = NEW.created_at
+        highest_bid_time   = NEW.timestamp
     WHERE id = NEW.item_id
         AND (
             highest_bid_amount IS NULL


### PR DESCRIPTION
This pull request makes a small update to the `update_item_highest_bid_after_insert.sql` migration function, ensuring that the `highest_bid_time` is set using the `NEW.timestamp` field rather than `NEW.created_at`. This helps maintain consistency with the correct timestamp field.

Related Issues:
- Resolved #108 