### PR TITLE
Add API For Get UserDetails by UserId

### DIFF
--- a/apps/backend/app/router.go
+++ b/apps/backend/app/router.go
@@ -37,6 +37,7 @@ func NewRouter(h *handlers.HandlerSet, jwtSecret []byte) *gin.Engine {
 
 	// Users
 	r.GET("/users", h.Users.ListUsers)
+	r.GET("/users/:user_id", h.Users.GetUserDetails)
 
 	return r
 }

--- a/apps/backend/database/users.go
+++ b/apps/backend/database/users.go
@@ -69,6 +69,21 @@ func (r *UserDatabase) GetUserByEmail(ctx context.Context, email string) (UserRo
 	return u, err
 }
 
+func (r *UserDatabase) GetUserDetailsByUserID(
+	ctx context.Context,
+	userID string,
+) (UserPublic, error) {
+	var u UserPublic
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id::text, email, username, verified
+		 FROM users
+		 WHERE id = $1`,
+		userID,
+	).Scan(&u.ID, &u.Email, &u.Username, &u.Verified)
+	return u, err
+}
+
+
 func IsUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {

--- a/apps/backend/handlers/users.go
+++ b/apps/backend/handlers/users.go
@@ -67,3 +67,26 @@ func (h *UserHandler) ListUsers(c *gin.Context) {
 		NextCursor: nextCursor,
 	})
 }
+
+func (h *UserHandler) GetUserDetails(c *gin.Context) {
+	userID := c.Param("user_id")
+	if strings.TrimSpace(userID) == "" {
+		c.JSON(http.StatusBadRequest, utils.NewError("VALIDATION_ERROR", "user_id required", nil))
+		return
+	}
+
+	u, err := h.users.GetUserDetailsByUserID(c.Request.Context(), userID)
+	if err != nil {
+		if err == database.ErrNotFound {
+			c.JSON(http.StatusNotFound, utils.NewError("NOT_FOUND", "user not found", nil))
+			return
+		}
+		c.JSON(http.StatusInternalServerError, utils.NewError("INTERNAL_ERROR", "database error", nil))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"email":    u.Email,
+		"username": u.Username,
+	})
+}


### PR DESCRIPTION
## Add API: Get User Details by User ID

### Summary
Add a new backend API to fetch basic user details by `user_id`. The endpoint returns minimal public information and follows existing handler and database patterns.

### What’s Added
- New API endpoint: `GET /users/:user_id`
- New database function to fetch user details by ID
- Proper error handling for not found, validation, and database errors

### Response Example
{
  "email": "user@example.com",
  "username": "johndoe"
}

### Implementation Details
- Added `GetUserDetailsByUserID` in UserDatabase
- Added `GetUserDetails` handler in UserHandler
- Registered route in router.go

### Related Issues
- Resolved #102 