### PR TITLE
Update docs for feature-extractor consistency

### DIFF
--- a/docs/api/CONTRACT.md
+++ b/docs/api/CONTRACT.md
@@ -1068,7 +1068,7 @@ Start feature extraction for an item using its images.
 - Path: `/agents/feature_extractor/extract_item_features`
 
 Request (example):
-
+```json
     {
       "item_id": "uuid",
       "image_keys": [
@@ -1079,8 +1079,14 @@ Request (example):
         "https://<accountid>.r2.cloudflarestorage.com/<bucket>/uploads/...?...signature...",
         "https://<accountid>.r2.cloudflarestorage.com/<bucket>/uploads/...?...signature..."
       ],
-      "callback_url": "https://<go-backend>/internal/items/<item_id>/features"
+      "callback_url": "https://<go-backend>/internal/items/<item_id>/features",
+      "metadata" : {
+        "author"  : "artwork-author", // can be [null]
+        "title"   : "artwork-title", // can be [null]
+        "year"    : "artwork-year-created" //can be [null]
+      }
     }
+```
 
 Response 200:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,6 +232,7 @@ The Feature Extraction feature analyzes an item’s uploaded images to generate 
    - `image_keys`
    - `image_get_urls` (presigned)
    - `callback_url` (internal endpoint to store features)
+   - `metadata` (image metadata, e.g. title, author, year)
 7. AI Backend downloads the images using the presigned GET URLs and extracts a JSON `features` payload.
 8. AI Backend calls the Backend internal endpoint to update the item:
    - Backend writes `items.features = <features JSON>` (JSONB)


### PR DESCRIPTION
This pull request updates the API contract and architecture documentation to support passing metadata (such as author, title, and year) when extracting features for an item using its images. The changes clarify how metadata should be included in requests and update the documented request/response examples accordingly.

**API contract and documentation improvements:**

* Added a `metadata` field (with `author`, `title`, and `year`, each nullable) to the request body for the `/agents/feature_extractor/extract_item_features` endpoint in `CONTRACT.md`, and updated the example request to include this field.
* Updated the architecture documentation to include `metadata` as part of the parameters sent to the AI backend for feature extraction.
* Properly formatted the example JSON request in the API contract with code block markers for clarity.

**Related Issues:**

* Resolved #119 