### PR TITLE
Add AI extracted features to GET item

### DIFF
--- a/apps/backend/database/items.go
+++ b/apps/backend/database/items.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -25,7 +26,7 @@ type Item struct {
 	Title            string          `json:"title"`
 	Description      *string         `json:"description,omitempty"`
 	Author           *string         `json:"author,omitempty"`
-	Features         any             `json:"features,omitempty"`
+	Features         *map[string]any `json:"features,omitempty"`
 	YearCreated      *int            `json:"year_created,omitempty"`
 	Height           *float64        `json:"height,omitempty"`
 	Width            *float64        `json:"width,omitempty"`
@@ -174,7 +175,12 @@ func (r *ItemDatabase) CreateItem(ctx context.Context, a CreateItemArgs) (Item, 
 		it.HighestBidTime = &v
 	}
 
-	_ = featStr // features left nil for now
+	if featStr != "" {
+		var feat map[string]any
+		if err := json.Unmarshal([]byte(featStr), &feat); err == nil {
+			it.Features = &feat
+		}
+	}
 	return it, nil
 }
 
@@ -271,7 +277,12 @@ func (r *ItemDatabase) GetItemByID(ctx context.Context, itemID string) (Item, er
 		it.HighestBidTime = &v
 	}
 
-	_ = featStr
+	if featStr != "" {
+		var feat map[string]any
+		if err := json.Unmarshal([]byte(featStr), &feat); err == nil {
+			it.Features = &feat
+		}
+	}
 	return it, nil
 }
 

--- a/docs/api/CONTRACT.md
+++ b/docs/api/CONTRACT.md
@@ -399,6 +399,11 @@ Returns item details + pictures + current bid state (if you compute it).
     "highest_bid_amount": 10500,
     "highest_bidder_id": "uuid",
     "highest_bid_time": "2026-01-27T13:22:10Z",
+    "features": {
+      "vision_brushstroke": {},
+      "vision_blending": {},
+      "vision_physicality": {},
+    },
     "pictures": [
       {
         "id": "uuid",
@@ -466,6 +471,7 @@ Create a new auction item. Seller supplies basic info + image URLs (uploaded sep
     "highest_bid_amount": null,
     "highest_bidder_id": null,
     "highest_bid_time": null,
+    "features": {},
     "pictures": [
       {
         "id": "uuid",


### PR DESCRIPTION
This pull request improves how the `features` field is handled for auction items in both the backend and API documentation. The main change is to ensure that `features` is consistently represented as a map in the backend, and that it is correctly serialized and deserialized as JSON when creating or retrieving items. The API documentation is also updated to reflect the new structure.

Backend improvements for `features` field:

* Changed the `features` field in the `Item` struct from `any` to `*map[string]any` for better type safety and clarity (`apps/backend/database/items.go`).
* Updated the `CreateItem` and `GetItemByID` methods to unmarshal the `features` JSON string into a map and assign it to the `Item` struct if present (`apps/backend/database/items.go`). [[1]](diffhunk://#diff-11aecdc855351dd519d1b05488af440bf2005864336e8ee993598dcf2d428aeaL177-R183) [[2]](diffhunk://#diff-11aecdc855351dd519d1b05488af440bf2005864336e8ee993598dcf2d428aeaL274-R285)
* Added the `"encoding/json"` import to support JSON unmarshalling (`apps/backend/database/items.go`).

API documentation updates:

* Updated the example response for fetching item details to include a sample `features` object (`docs/api/CONTRACT.md`).
* Updated the example response for creating a new auction item to include an empty `features` object (`docs/api/CONTRACT.md`).

Related Issues:

* Resolved #136 