### PR TITLE
Fix working-directory in deploy actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push backend
+        working-directory: apps/backend
         run: |
           docker build -t ghcr.io/${{ github.repository_owner }}/artium-backend:latest -f apps/backend/Dockerfile .
           docker push ghcr.io/${{ github.repository_owner }}/artium-backend:latest
 
       - name: Build & push agents
+        working-directory: apps/agents
         run: |
           docker build -t ghcr.io/${{ github.repository_owner }}/artium-agents:latest -f apps/agents/Dockerfile .
           docker push ghcr.io/${{ github.repository_owner }}/artium-agents:latest


### PR DESCRIPTION
This pull request makes a minor improvement to the deployment workflow by specifying the working directory for Docker build and push steps. This helps ensure that the Docker commands are run in the correct context for each application.

- Deployment workflow improvement:
  * Added `working-directory` to the "Build & push backend" and "Build & push agents" steps in `.github/workflows/deploy.yml` to ensure Docker builds are executed in the correct directories.