### PR TITLE
Extend timeout GitHub Actions Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - name: Deploy on VM (pull & restart)
         uses: appleboy/ssh-action@v1.0.3
+        timeout-minutes: 30
         with:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USER }}


### PR DESCRIPTION
This pull request makes a minor adjustment to the deployment workflow configuration. The change sets a timeout for the "Deploy on VM (pull & restart)" step to help prevent hanging deployments.

* Increased the timeout for the `appleboy/ssh-action` step in `.github/workflows/deploy.yml` to 30 minutes, ensuring deployments do not hang indefinitely.

**Related Issues:**

* Resolved #149 