### PR TITLE
Move the timeout into Action job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,10 +36,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build-and-push
+    timeout-minutes: 45
     steps:
       - name: Deploy on VM (pull & restart)
         uses: appleboy/ssh-action@v1.0.3
-        timeout-minutes: 30
         with:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USER }}


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow by increasing the timeout for the deploy job from 30 minutes to 45 minutes.

- Increased the `timeout-minutes` setting for the `deploy` job in `.github/workflows/deploy.yml` from 30 to 45 minutes to allow more time for deployments.