### PR TITLE
Add timeout in appleboy/ssh-action for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,7 @@ jobs:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          command_timeout: 45m
           script: |
             cd ~/artium
             docker compose -f docker-compose.prod.yml pull


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow by increasing the SSH command timeout to 45 minutes. This helps ensure that longer deployment operations have sufficient time to complete without timing out.