### PR TITLE
Refactor Deployment to be Executed on Tag

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -33,6 +33,10 @@ jobs:
   deploy-preview:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      VERCEL_CLI_VERSION: 41.4.1
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     defaults:
       run:
         working-directory: ./apps/frontend
@@ -47,30 +51,25 @@ jobs:
           node-version: 20
 
       - name: Install Vercel CLI
-        run: npm i -g vercel@latest
+        run: npm i -g vercel@${{ env.VERCEL_CLI_VERSION }}
 
       - name: Pull Vercel Environment (Preview)
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Build (Preview)
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Deploy Preview
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
   deploy-production:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: verify-tag-on-main
+    env:
+      VERCEL_CLI_VERSION: 41.4.1
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     defaults:
       run:
         working-directory: ./apps/frontend
@@ -85,22 +84,13 @@ jobs:
           node-version: 20
 
       - name: Install Vercel CLI
-        run: npm i -g vercel@latest
+        run: npm i -g vercel@${{ env.VERCEL_CLI_VERSION }}
 
       - name: Pull Vercel Environment (Production)
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Build (Production)
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Deploy Production
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -3,10 +3,35 @@ name: Deploy to Vercel
 on:
   pull_request:
   push:
-    branches: [main]
+    tags: ['v*.*.*']
+
+permissions:
+  contents: read
 
 jobs:
-  deploy:
+  verify-tag-on-main:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag points to a commit on main
+        run: |
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag $GITHUB_REF_NAME does not match required pattern v<major>.<minor>.<patch>."
+            exit 1
+          fi
+
+          git fetch origin main --depth=1
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Tag commit $GITHUB_SHA is not on main. Skipping deployment."
+            exit 1
+          fi
+
+  deploy-preview:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -25,44 +50,56 @@ jobs:
         run: npm i -g vercel@latest
 
       - name: Pull Vercel Environment (Preview)
-        if: github.event_name == 'pull_request'
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
-      - name: Pull Vercel Environment (Production)
-        if: github.event_name == 'push'
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      # ✅ Build PREVIEW for PRs (default behavior is preview)
       - name: Build (Preview)
-        if: github.event_name == 'pull_request'
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
-      # ✅ Build PRODUCTION for pushes to main
-      - name: Build (Production)
-        if: github.event_name == 'push'
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
       - name: Deploy Preview
-        if: github.event_name == 'pull_request'
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
+  deploy-production:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: verify-tag-on-main
+    defaults:
+      run:
+        working-directory: ./apps/frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+
+      - name: Pull Vercel Environment (Production)
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build (Production)
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
       - name: Deploy Production
-        if: github.event_name == 'push'
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+env:
+  NODE_VERSION: 22
+  VERCEL_CLI_VERSION: 50.16.0
+
 jobs:
   verify-tag-on-main:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -18,15 +22,19 @@ jobs:
           fetch-depth: 0
 
       - name: Ensure tag points to a commit on main
+        shell: bash
         run: |
           if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Tag $GITHUB_REF_NAME does not match required pattern v<major>.<minor>.<patch>."
             exit 1
           fi
 
-          git fetch origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "Tag commit $GITHUB_SHA is not on main. Skipping deployment."
+          git fetch origin main --prune
+          TAG_COMMIT="$(git rev-list -n 1 "${GITHUB_REF}")"
+          echo "Resolved tag commit: ${TAG_COMMIT}"
+
+          if ! git merge-base --is-ancestor "${TAG_COMMIT}" origin/main; then
+            echo "Tag commit ${TAG_COMMIT} is not on main. Skipping deployment."
             exit 1
           fi
 
@@ -34,24 +42,26 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
-      VERCEL_CLI_VERSION: 41.4.1
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     defaults:
       run:
         working-directory: ./apps/frontend
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Vercel CLI
         run: npm i -g vercel@${{ env.VERCEL_CLI_VERSION }}
+
+      - name: Show versions
+        run: |
+          node -v
+          npm -v
+          vercel --version
 
       - name: Pull Vercel Environment (Preview)
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
@@ -67,24 +77,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify-tag-on-main
     env:
-      VERCEL_CLI_VERSION: 41.4.1
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     defaults:
       run:
         working-directory: ./apps/frontend
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Vercel CLI
         run: npm i -g vercel@${{ env.VERCEL_CLI_VERSION }}
+
+      - name: Show versions
+        run: |
+          node -v
+          npm -v
+          vercel --version
 
       - name: Pull Vercel Environment (Production)
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   verify-tag-on-main:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
             exit 1
           fi
 
-          git fetch origin main --depth=1
+          git fetch origin main
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
             echo "Tag commit $GITHUB_SHA is not on main. Skipping deployment."
             exit 1

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -57,12 +57,6 @@ jobs:
       - name: Install Vercel CLI
         run: npm i -g vercel@${{ env.VERCEL_CLI_VERSION }}
 
-      - name: Show versions
-        run: |
-          node -v
-          npm -v
-          vercel --version
-
       - name: Pull Vercel Environment (Preview)
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
@@ -91,12 +85,6 @@ jobs:
 
       - name: Install Vercel CLI
         run: npm i -g vercel@${{ env.VERCEL_CLI_VERSION }}
-
-      - name: Show versions
-        run: |
-          node -v
-          npm -v
-          vercel --version
 
       - name: Pull Vercel Environment (Production)
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,15 +2,36 @@ name: Build & Deploy (VM)
 
 on:
   push:
-    branches: [main]
+    tags: ['v*.*.*']
 
 permissions:
   contents: read
   packages: write
 
 jobs:
+  verify-tag-on-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag points to a commit on main
+        run: |
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag $GITHUB_REF_NAME does not match required pattern v<major>.<minor>.<patch>."
+            exit 1
+          fi
+
+          git fetch origin main --depth=1
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Tag commit $GITHUB_SHA is not on main. Skipping deployment."
+            exit 1
+          fi
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: verify-tag-on-main
     steps:
       - uses: actions/checkout@v4
 
@@ -24,14 +45,22 @@ jobs:
       - name: Build & push backend
         working-directory: apps/backend
         run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/artium-backend:latest -f Dockerfile .
+          docker build \
+            -t ghcr.io/${{ github.repository_owner }}/artium-backend:latest \
+            -t ghcr.io/${{ github.repository_owner }}/artium-backend:${{ github.ref_name }} \
+            -f Dockerfile .
           docker push ghcr.io/${{ github.repository_owner }}/artium-backend:latest
+          docker push ghcr.io/${{ github.repository_owner }}/artium-backend:${{ github.ref_name }}
     
       - name: Build & push agents
         working-directory: apps/agents
         run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/artium-agents:latest -f Dockerfile .
+          docker build \
+            -t ghcr.io/${{ github.repository_owner }}/artium-agents:latest \
+            -t ghcr.io/${{ github.repository_owner }}/artium-agents:${{ github.ref_name }} \
+            -f Dockerfile .
           docker push ghcr.io/${{ github.repository_owner }}/artium-agents:latest
+          docker push ghcr.io/${{ github.repository_owner }}/artium-agents:${{ github.ref_name }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
             exit 1
           fi
 
-          git fetch origin main --depth=1
+          git fetch origin main
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
             echo "Tag commit $GITHUB_SHA is not on main. Skipping deployment."
             exit 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,40 +258,6 @@ sequenceDiagram
 
 **Diagram caption:** User-driven visualization flow from upload to polling result, including AI processing and backend job tracking.
 
-### Diagram: Visualizer service workflow
-```mermaid
-flowchart TD
-  Start([Visualizer job received]) --> Fetch[Fetch item + room images]
-  Fetch --> Validate[Validate image formats/size]
-  Validate --> Preprocess[Preprocess/resize/normalize]
-  Preprocess --> Merge[Run visualizer model: merge art into room]
-  Merge --> Describe[Generate text description]
-  Describe --> Upload[Upload merged image to R2]
-  Upload --> Callback[Callback backend with result]
-  Callback --> Done([Job complete])
-
-  Validate -.->|Invalid image| Fail[Mark job failed]
-  Merge -.->|Model error| Fail
-  Upload -.->|Storage error| Fail
-```
-
-**Diagram caption:** Internal AI visualizer processing steps with failure branches.
-
-### Diagram: Visualizer job state transitions
-```mermaid
-stateDiagram-v2
-  [*] --> queued
-  queued --> processing: worker picks job
-  processing --> succeeded: result_image_key + description saved
-  processing --> failed: error_message saved
-  failed --> queued: retry (optional)
-```
-
-**Diagram caption:** Job lifecycle for `visualization_jobs`, including optional retry on failure.
-
-### Notes
-- Do not store signed URLs in Postgres; store only keys and derive URLs or sign GET on demand.
-
 ---
 
 ## AI Feature Extraction on Item Upload
@@ -402,12 +368,84 @@ erDiagram
 
 ---
 
-## Optional Extensions (later)
-These are the future modules mentioned in the sketch. They will be added as separate endpoints/services, but are **not** specified here yet:
-- **Recommender**: show similar items on the item page.
-- **Visualizer**: allow buyers to preview an artwork in a room context.
-- **Art Valuation**: provide additional pricing/insight widgets.
+## Deployment & Release Workflow (GitHub Actions)
 
-For now, the API should be structured so these can be added without breaking core auction flows.
+Production deployments are gated by release tags and branch ancestry checks.
+
+### Release policy
+- Only tags matching `v<major>.<minor>.<patch>` (example: `v1.2.3`) trigger production deploy workflows.
+- The tag commit must be reachable from `main`.
+- Frontend preview deployments for pull requests remain enabled and are not part of the release-tag path.
+
+### Backend/Agents release behavior (GHCR + VM)
+- The deploy workflow builds and pushes two image tags per service:
+  - `latest`
+  - the git tag itself (for example, `v1.2.3`)
+- After image push, the VM deployment job pulls and restarts services via Compose.
+
+### Diagram: GitHub Actions release flow
+```mermaid
+flowchart TD
+  DEV[Developer] --> TAG[Push git tag vX.Y.Z]
+
+  TAG --> GH1[GitHub Actions: deploy.yml]
+  TAG --> GH2[GitHub Actions: deploy-frontend.yml]
+
+  GH1 --> C1{Tag matches vX.Y.Z?}
+  GH2 --> C2{Tag matches vX.Y.Z?}
+
+  C1 -->|No| STOP1[Stop workflow]
+  C2 -->|No| STOP2[Stop workflow]
+
+  C1 -->|Yes| M1{Tag commit on main?}
+  C2 -->|Yes| M2{Tag commit on main?}
+
+  M1 -->|No| STOP3[Stop workflow]
+  M2 -->|No| STOP4[Stop workflow]
+
+  M1 -->|Yes| B1[Build backend + agents images]
+  B1 --> P1[Push GHCR tags: latest + vX.Y.Z]
+  P1 --> VM[SSH deploy on VM\ndocker compose pull/up]
+
+  M2 -->|Yes| FE[Build + deploy frontend production on Vercel]
+
+  PR[Pull Request] --> PREVIEW[Frontend preview deploy path]
+```
+
+**Diagram caption:** Release deployments only run for semver tags on commits contained in `main`; backend images are versioned in GHCR and deployed to VM, while frontend keeps an independent PR preview path.
+
+### Diagram: Visualizer service workflow
+```mermaid
+flowchart TD
+  Start([Visualizer job received]) --> Fetch[Fetch item + room images]
+  Fetch --> Validate[Validate image formats/size]
+  Validate --> Preprocess[Preprocess/resize/normalize]
+  Preprocess --> Merge[Run visualizer model: merge art into room]
+  Merge --> Describe[Generate text description]
+  Describe --> Upload[Upload merged image to R2]
+  Upload --> Callback[Callback backend with result]
+  Callback --> Done([Job complete])
+
+  Validate -.->|Invalid image| Fail[Mark job failed]
+  Merge -.->|Model error| Fail
+  Upload -.->|Storage error| Fail
+```
+
+**Diagram caption:** Internal AI visualizer processing steps with failure branches.
+
+### Diagram: Visualizer job state transitions
+```mermaid
+stateDiagram-v2
+  [*] --> queued
+  queued --> processing: worker picks job
+  processing --> succeeded: result_image_key + description saved
+  processing --> failed: error_message saved
+  failed --> queued: retry (optional)
+```
+
+**Diagram caption:** Job lifecycle for `visualization_jobs`, including optional retry on failure.
+
+### Notes
+- Do not store signed URLs in Postgres; store only keys and derive URLs or sign GET on demand.
 
 ---


### PR DESCRIPTION
This pull request introduces a new release workflow for production deployments, ensuring that only semantic version tags (`v<major>.<minor>.<patch>`) on commits contained in `main` trigger deploy actions. It also updates the backend and frontend deployment jobs to use this tagging strategy, adds branch ancestry checks, and improves documentation with diagrams and explanations. Preview deployments for pull requests remain unchanged. The backend and agent Docker images are now tagged with both `latest` and the release tag for better version tracking.

**Deployment workflow changes:**

* Production deployment jobs in `.github/workflows/deploy-frontend.yml` and `.github/workflows/deploy.yml` are now triggered only by tags matching the pattern `v*.*.*` instead of pushes to `main`. [[1]](diffhunk://#diff-64f2f74f4d05399d57c48809ad9ec9bc55550bd51d5faf574866753ea4d781dbL6-R34) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L5-R34)
* Added a `verify-tag-on-main` job to both workflows that checks if the tag commit is an ancestor of `main`, gating production deployments on branch ancestry. [[1]](diffhunk://#diff-64f2f74f4d05399d57c48809ad9ec9bc55550bd51d5faf574866753ea4d781dbL6-R34) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L5-R34)
* Backend and agent Docker images are now built and pushed with both `latest` and the tag version (e.g., `v1.2.3`) to GHCR, improving traceability of releases.

**Frontend deployment improvements:**

* Frontend preview deployments for pull requests are separated from production deployments, maintaining independent deployment paths for PRs and releases.

**Documentation updates:**

* `docs/architecture.md` now includes a section and diagram explaining the new deployment and release workflow, including tagging policy, ancestry checks, and image tagging. The previous optional extensions section was replaced with this new documentation.
* The visualizer workflow and job state diagrams were moved and clarified in the documentation for better visibility and context. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L261-L294) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L405-R449)

**Related Features:**

* Resolved #153 