### PR TITLE
ci(frontend): skip deploys when frontend is unchanged

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -2,6 +2,9 @@ name: Deploy to Vercel
 
 on:
   pull_request:
+    # Preview deployments are only relevant when the frontend changed.
+    paths:
+      - 'apps/frontend/**'
   push:
     tags: ['v*.*.*']
 
@@ -13,8 +16,43 @@ env:
   VERCEL_CLI_VERSION: 50.16.0
 
 jobs:
-  verify-tag-on-main:
+  detect-frontend-changes:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    outputs:
+      frontend_changed: ${{ steps.frontend-diff.outputs.frontend_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect frontend changes since previous release tag
+        id: frontend-diff
+        shell: bash
+        run: |
+          TAG_COMMIT="$(git rev-list -n 1 "${GITHUB_REF}")"
+          PREVIOUS_TAG="$(git describe --tags --match 'v*.*.*' --abbrev=0 "${TAG_COMMIT}^" 2>/dev/null || true)"
+
+          # Push tag events do not support path filters, so compare this release
+          # against the previous release tag before running the production deploy.
+          if [[ -z "${PREVIOUS_TAG}" ]]; then
+            echo "No previous release tag found. Treating frontend as changed."
+            echo "frontend_changed=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "Comparing ${PREVIOUS_TAG}..${GITHUB_REF_NAME} for frontend changes."
+          if git diff --quiet "${PREVIOUS_TAG}" "${TAG_COMMIT}" -- apps/frontend; then
+            echo "No frontend changes detected."
+            echo "frontend_changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Frontend changes detected."
+            echo "frontend_changed=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+  verify-tag-on-main:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && needs.detect-frontend-changes.outputs.frontend_changed == 'true'
+    needs: detect-frontend-changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -67,9 +105,11 @@ jobs:
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
 
   deploy-production:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && needs.detect-frontend-changes.outputs.frontend_changed == 'true'
     runs-on: ubuntu-latest
-    needs: verify-tag-on-main
+    needs:
+      - detect-frontend-changes
+      - verify-tag-on-main
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
This pull request updates the `deploy-frontend.yml` GitHub Actions workflow to ensure that preview and production deployments for the frontend only run when there are actual changes to the frontend code. The workflow now detects frontend changes between release tags and skips unnecessary deployments, improving efficiency and avoiding redundant deploys.

Key changes:

**Frontend Change Detection:**
* Added a new `detect-frontend-changes` job that checks if there have been any changes in the `apps/frontend` directory since the previous release tag. It sets an output variable (`frontend_changed`) to control subsequent jobs.

**Conditional Deployments:**
* Updated the `pull_request` trigger to only run preview deployments when files in `apps/frontend/**` change.
* Modified the `verify-tag-on-main` and `deploy-production` jobs to depend on `detect-frontend-changes` and only run if frontend changes are detected, preventing unnecessary production deployments. [[1]](diffhunk://#diff-64f2f74f4d05399d57c48809ad9ec9bc55550bd51d5faf574866753ea4d781dbL16-R56) [[2]](diffhunk://#diff-64f2f74f4d05399d57c48809ad9ec9bc55550bd51d5faf574866753ea4d781dbL70-R112)

**Related Issues:**

* Resolve #190 